### PR TITLE
add shinyjs:: to show/hide

### DIFF
--- a/shiny/apps/pipelineRunner/modules/appSteps/configureJob/configureJob_server.R
+++ b/shiny/apps/pipelineRunner/modules/appSteps/configureJob/configureJob_server.R
@@ -152,11 +152,11 @@ activeJobFile <- reactive({
 observeEvent(jobFiles$selected(), {
     selectedRow <- jobFiles$selected()
     isSelection <- !is.null(selectedRow) && !is.na(selectedRow)
-    toggle(
+    shinyjs::toggle(
         selector = "span.requiresJobFile", 
         condition = isSelection
     )
-    toggle(
+    shinyjs::toggle(
         selector = "div.requiresJobFileMessage", 
         condition = !isSelection
     )
@@ -192,8 +192,8 @@ observeEvent({
         settings$set("Job_Files", "Job_File_Edit_Mode", if(isInputs) "Script Editor" else "User Inputs")
         return(NULL)
     }
-    toggle(id = "uiBasedJobEditing",   condition =  isInputs)
-    toggle(id = "textBasedJobEditing", condition = !isInputs)
+    shinyjs::toggle(id = "uiBasedJobEditing",   condition =  isInputs)
+    shinyjs::toggle(id = "textBasedJobEditing", condition = !isInputs)
     editMode(
         if(is.null(activeJobFile())) editModes$none 
         else if(isInputs) editModes$inputs 

--- a/shiny/apps/pipelineRunner/modules/appSteps/runJob/runJob_server.R
+++ b/shiny/apps/pipelineRunner/modules/appSteps/runJob/runJob_server.R
@@ -32,11 +32,11 @@ activeJobFile <- reactive({
 observe({
     selectedRow <- jobFiles$selected()
     isSelection <- !is.null(selectedRow) && !is.na(selectedRow)
-    toggle(
+    shinyjs::toggle(
         selector = "span.requiresJobFile", 
         condition = isSelection
     )
-    toggle(
+    shinyjs::toggle(
         selector = "div.requiresJobFileMessage", 
         condition = !isSelection
     )
@@ -363,7 +363,7 @@ fillPre <- function(mdiOutputData){
     x <- mdiOutputData$data
     if(x$success && mdiOutputData$invalidateStatus) 
         invalidateStatus(isolate({ invalidateStatus() }) + 1)
-    toggle(session$ns("refreshOutput"), asis = TRUE, condition = mdiOutputData$refreshable)
+    shinyjs::toggle(session$ns("refreshOutput"), asis = TRUE, condition = mdiOutputData$refreshable)
     tags$pre( 
         class = if(x$success) "" else "command-output-error",
         paste(x$results, collapse = "\n") 

--- a/shiny/apps/pipelineRunner/modules/widgets/jobFileInputEditor/jobFileInputEditor_server.R
+++ b/shiny/apps/pipelineRunner/modules/widgets/jobFileInputEditor/jobFileInputEditor_server.R
@@ -89,7 +89,7 @@ observeEvent({
         selected = actions,
         inline = TRUE
     )   
-    toggle('actionSelectors', condition = length(config$actions) > 1)  
+    shinyjs::toggle('actionSelectors', condition = length(config$actions) > 1)  
 })
 
 #----------------------------------------------------------------------
@@ -228,9 +228,9 @@ output$optionFamilies <- renderUI({
 requiredOnly <- reactiveVal(FALSE)
 observeEvent(requiredOnly(), { 
     reqOnly <- requiredOnly()
-    toggle('showRequiredOnly', condition = !reqOnly)
-    toggle('showAllOptions',   condition =  reqOnly)
-    toggle(selector = ".pr-optional-input", condition = !reqOnly)
+    shinyjs::toggle('showRequiredOnly', condition = !reqOnly)
+    shinyjs::toggle('showAllOptions',   condition =  reqOnly)
+    shinyjs::toggle(selector = ".pr-optional-input", condition = !reqOnly)
 })
 observeEvent(input$showRequiredOnly, { requiredOnly(TRUE) })
 observeEvent(input$showAllOptions,   { requiredOnly(FALSE) })

--- a/shiny/shared/server.R
+++ b/shiny/shared/server.R
@@ -35,8 +35,8 @@ serverFn <- function(input, output, session,
     sessionInput <- input
     sessionSession <- session
     source("server/initializeSession.R", local = TRUE)
-    if(!initializeSessionSuccess) return( show(CONSTANTS$apps$scriptSourceError) )
-    show(if(MbRAM_beforeStart > serverEnv$MAX_MB_RAM_BEFORE_START)
+    if(!initializeSessionSuccess) return( shinyjs::show(CONSTANTS$apps$scriptSourceError) )
+    shinyjs::show(if(MbRAM_beforeStart > serverEnv$MAX_MB_RAM_BEFORE_START)
          CONSTANTS$apps$serverBusy else CONSTANTS$apps$launchPage)        
     createSpinner() # create the loading spinner
     source("server/observeAuthentication.R", local = TRUE)

--- a/shiny/shared/server/observeAuthentication.R
+++ b/shiny/shared/server/observeAuthentication.R
@@ -24,7 +24,7 @@ observeEvent(input$keyedLoginButton, {
 
 # show help on the login page about external authorization sources
 observeEvent(input$showLoginHelp, {
-    show('login-help')
+    shinyjs::show('login-help')
 })
 
 # determine whether session has an authorized user

--- a/shiny/shared/session/modules/widgets/dataSources/sampleSetGroupType/sampleSetGroupType_server.R
+++ b/shiny/shared/session/modules/widgets/dataSources/sampleSetGroupType/sampleSetGroupType_server.R
@@ -52,13 +52,13 @@ observeEvent(input$sampleSet, {
     mapply(function(id, i){
         cssId <- paste0('#', parentNs(id))
         x <- sourceOptions$categories[[id]]
-        if(is.null(x)) return( hide(selector = cssId) ) 
+        if(is.null(x)) return( shinyjs::hide(selector = cssId) ) 
         y <- categories[[i]]
-        if(length(y) <= 1) return( hide(selector = cssId) ) 
+        if(length(y) <= 1) return( shinyjs::hide(selector = cssId) ) 
         z <- seq_along(y)
         names(z) <- y
         updateSelectInput(session, id, choices = z, selected = values[[id]])
-        show(selector = cssId)
+        shinyjs::show(selector = cssId)
     }, c('group', 'type'), 1:2)
 })
 

--- a/shiny/shared/session/modules/widgets/framework/aceEditor/aceEditor_server.R
+++ b/shiny/shared/session/modules/widgets/framework/aceEditor/aceEditor_server.R
@@ -49,7 +49,7 @@ invalidateTree <- reactiveVal(0)
 output$tree <- shinyTree::renderTree({
     req(input$baseDir)
     invalidateTree()
-    show(selector = spinnerSelector)
+    shinyjs::show(selector = spinnerSelector)
     relPaths <- if(isSingleFile) basename(showFile)
                 else list.files(input$baseDir, include.dirs = TRUE, recursive = TRUE)   
     paths <- file.path(input$baseDir, relPaths)
@@ -60,7 +60,7 @@ output$tree <- shinyTree::renderTree({
     x <- as.list(tree)
     x$name <- NULL
     if(isSingleFile) isolate({ setActiveTab(paths) })
-    hide(selector = spinnerSelector)
+    shinyjs::hide(selector = spinnerSelector)
     x
 })
 # respond to a file tree click
@@ -92,14 +92,14 @@ tabs <- reactiveVal(if(is.null(tabs)) data.table(
     message = character()
 ) else tabs)
 setActiveTab <- function(activePath, closingPath = NULL, deselect = FALSE){
-    show(selector = spinnerSelector)
+    shinyjs::show(selector = spinnerSelector)
     tabs <- tabs()
     if(deselect){ # no selected tab, working in a directory
         tabs[, active := FALSE]
         tabs(tabs) 
         invalidateTabs( invalidateTabs() + 1 )
         clearAceSession(editorId)
-        hide(selector = spinnerSelector) 
+        shinyjs::hide(selector = spinnerSelector) 
         return()
     }   
     if(!is.null(activePath)){
@@ -117,7 +117,7 @@ setActiveTab <- function(activePath, closingPath = NULL, deselect = FALSE){
         terminateAceSession(editorId, closingPath, activePath)
     }
     tabs(tabs) 
-    hide(selector = spinnerSelector) 
+    shinyjs::hide(selector = spinnerSelector) 
     checkCodeSyntax(activePath, contents)     
 }
 invalidateTabs <- reactiveVal(0)
@@ -224,23 +224,23 @@ output$file <- renderText({
     directory <- directory()
     path <- if(is.null(directory)) tabs()[active == TRUE, path] else directory
     path <- gsub(paste0(serverEnv$MDI_DIR, '/'), '', path)
-    hide(selector = '.ace-file-option')
+    shinyjs::hide(selector = '.ace-file-option')
     if(state == states$waiting){
-        show("fileMenu")
-        hide("path-edit-wrapper")
+        shinyjs::show("fileMenu")
+        shinyjs::hide("path-edit-wrapper")
         path
     } else if (state == states$choosing){
-        show("fileMenu")
-        show(selector = if(is.null(directory) && nrow(tabs()) > 0) ".ace-file-action" else ".ace-dir-action")
-        hide("path-edit-wrapper")
+        shinyjs::show("fileMenu")
+        shinyjs::show(selector = if(is.null(directory) && nrow(tabs()) > 0) ".ace-file-action" else ".ace-dir-action")
+        shinyjs::hide("path-edit-wrapper")
         path
     } else {
         freezeReactiveValue(input, "confirmAction")
         updateActionButton(session, "confirmAction", label = action$name)
-        show("confirmAction")
-        show("cancelAction")
+        shinyjs::show("confirmAction")
+        shinyjs::show("cancelAction")
         if(!is.null(action$editPath)) {
-            show("path-edit-wrapper")
+            shinyjs::show("path-edit-wrapper")
             freezeReactiveValue(input, "pathEdit")
             updateTextInput(session, "pathEdit", 
                             value = if(action$editPath) path else "")
@@ -286,11 +286,11 @@ observers$fileMenu <- observeEvent(input$fileMenu, {
     setTimeout(toggleFileMenu, states$waiting)
 })
 observers$confirmAction <- observeEvent(input$confirmAction, {
-    show(selector = spinnerSelector)
+    shinyjs::show(selector = spinnerSelector)
     action <- pendingFileAction()
     action$do(action$path)
     invalidateTree( invalidateTree() + 1 )
-    hide(selector = spinnerSelector)
+    shinyjs::hide(selector = spinnerSelector)
     toggleFileMenu(NULL, states$waiting)
     pendingFileAction(list())
     if(!is.null(action$close) && action$close) closeTab(action$path)

--- a/shiny/shared/session/modules/widgets/framework/commandTerminal/commandTerminal_server.R
+++ b/shiny/shared/session/modules/widgets/framework/commandTerminal/commandTerminal_server.R
@@ -99,7 +99,7 @@ observers$doCommand <- observeEvent(doCommand(), {
     command <- interceptTerminalCommands(input$command, workingDir = workingDir, 
                                          prefix = prefix, onExit = onExit)
     req(command)
-    show(selector = spinnerSelector)  
+    shinyjs::show(selector = spinnerSelector)  
     systemCommand <- if(is.null(host)) { # enable terminal to work on login host (the default) or a node
         paste0(                "cd '", dir, "'; ", runtimeCommand, command, " 2>&1")
     } else {
@@ -131,7 +131,7 @@ observers$doCommand <- observeEvent(doCommand(), {
             )
         }) 
     )
-    hide(selector = spinnerSelector)
+    shinyjs::hide(selector = spinnerSelector)
     addCommandToHistory(prefix)
     results(x)
 })

--- a/shiny/shared/session/modules/widgets/framework/gitManager/gitManager_server.R
+++ b/shiny/shared/session/modules/widgets/framework/gitManager/gitManager_server.R
@@ -77,7 +77,7 @@ output$statusTable <- renderDT(
 # update the extended status of a clicked repository
 repoObserver <- rowSelectionObserver("statusTable", input)
 setRepoStatus <- function(showStatus = TRUE){
-    show(selector = spinnerSelector) 
+    shinyjs::show(selector = spinnerSelector) 
     dir <- repo()$dir
 
     # collect various bits of status and other metadata on the selected repo
@@ -144,7 +144,7 @@ setRepoStatus <- function(showStatus = TRUE){
         x$remoteBranches,        
         names(repo()$versions)
     ), selected = getGitHeadDisplay(repo()$head))
-    hide(selector = spinnerSelector) 
+    shinyjs::hide(selector = spinnerSelector) 
     status(x)
     if(showStatus) invalidateStatus( invalidateStatus() + 1 )
 }
@@ -177,7 +177,7 @@ observers$repoSelected <- observeEvent(repoObserver(), {
     isRepoSelected <- type != "app"
 
     # set the associated repository (if any)
-    toggle(selector = ".isRepoSelected", condition = isRepoSelected)
+    shinyjs::toggle(selector = ".isRepoSelected", condition = isRepoSelected)
     repo(switch(
         type,
         framework  = gitFrameworkStatus,
@@ -187,7 +187,7 @@ observers$repoSelected <- observeEvent(repoObserver(), {
     )) 
 
     # reset the repo status and UI
-    hide("messagePanel")
+    shinyjs::hide("messagePanel")
     pendingAction(NULL)
     if(isRepoSelected) setRepoStatus(TRUE) else {
         status(list(type = "app"))
@@ -236,7 +236,7 @@ output$warn <- renderText({
     pendingAction()$prompt
 })
 observers$message <- observeEvent(pendingAction(), {
-    toggle(
+    shinyjs::toggle(
         'messagePanel', 
         condition = !is.null(pendingAction()) && pendingAction()$message
     )
@@ -255,7 +255,7 @@ doMessageAction <- function(action, type, prompt, expr){
     } else {
         req(input$message)
         pendingAction(NULL)
-        hide("messagePanel")
+        shinyjs::hide("messagePanel")
         gitExpr(expr)
     }
 }
@@ -332,13 +332,13 @@ observers$checkout <- observeEvent(input$checkout, {
 output$output <- renderUI({
     expr <- gitExpr()    
     req(expr)
-    show(selector = spinnerSelector) 
+    shinyjs::show(selector = spinnerSelector) 
     output <- tryCatch(
         capture.output(eval(expr)),
         warning = function(w) w, 
         error = function(e) e
     ) 
-    hide(selector = spinnerSelector)  
+    shinyjs::hide(selector = spinnerSelector)  
     tags$pre(
         style = "max-height: 400px; overflow: auto;",
         paste(collapse = "\n", output)

--- a/shiny/shared/session/modules/widgets/framework/rConsole/rConsole_server.R
+++ b/shiny/shared/session/modules/widgets/framework/rConsole/rConsole_server.R
@@ -58,8 +58,8 @@ executeCode <- function(mode){
 }
 fillReactive <- function(id, expr){
     reactives[[id]](NULL)
-    hide(selector = ".r-console-pane")
-    show(id)        
+    shinyjs::hide(selector = ".r-console-pane")
+    shinyjs::show(id)        
     reactives[[id]](expr)
 }
 observers$codeEditorContentsId <- observeEvent(input[[codeEditorContentsId]], {
@@ -93,16 +93,16 @@ observeEvent(input$ls_sessionEnv, {
 # ... to generate one of several types of user-intended output
 #----------------------------------------------------------------------
 evalExpr <- function(target){
-    show(selector = spinnerSelector)
+    shinyjs::show(selector = spinnerSelector)
     tryCatch({
         x <- eval(reactives[[target]](), envir)
-        hide(selector = spinnerSelector)
+        shinyjs::hide(selector = spinnerSelector)
         x
     }, warning = function(warning){
-        hide(selector = spinnerSelector)
+        shinyjs::hide(selector = spinnerSelector)
         paste(collapse = "\n", warning)
     }, error = function(error){
-        hide(selector = spinnerSelector)
+        shinyjs::hide(selector = spinnerSelector)
         paste(collapse = "\n", error)
     }) 
 }

--- a/shiny/shared/session/modules/widgets/framework/serverCleanup/serverCleanup_server.R
+++ b/shiny/shared/session/modules/widgets/framework/serverCleanup/serverCleanup_server.R
@@ -30,12 +30,12 @@ handleSelectDelete <- function(d){
 }
 observers$deleteSelectedPackages <- observeEvent(input$deleteSelectedPackages, {
     req(selectedPackages)
-    show(selector = spinnerSelector)
+    shinyjs::show(selector = spinnerSelector)
     x <- dataPackages()
     packageDirs <- x[selectedPackages, packageDir]
     unlink(packageDirs, recursive = TRUE)
     dataPackages(x[!(packageDir %in% packageDirs)])
-    hide(selector = spinnerSelector)
+    shinyjs::hide(selector = spinnerSelector)
 })
 
 #----------------------------------------------------------------------

--- a/shiny/shared/session/modules/widgets/framework/settings/settings_server.R
+++ b/shiny/shared/session/modules/widgets/framework/settings/settings_server.R
@@ -75,7 +75,7 @@ initializeTemplate <- function(t){
                else if(nTabs >= 6 || maxTabSize > 16) 'l' 
                else if(nTabs >= 3 || maxTabSize > 8) 'm' else 's'
     inputWidth <<- if(workingSize == "l") 4 else if(workingSize == "m") 6 else 12
-    toggle(
+    shinyjs::toggle(
         id = fullGearId, 
         asis = TRUE, # does not work consistently to let shinyjs handle id resolution (not sure why)
         condition = nTabs > 0


### PR DESCRIPTION
An application using genomex-mdi-tools track browser inadvertently overrode the shinyjs::show() function, which was only being called as show(). These changes update all such calls to shinyjs::show(), shinyjs::hide(), and shinyjs::toggle() to prevent future collisions with common function names.